### PR TITLE
scheme functions functionality added

### DIFF
--- a/parsing/parser.hs
+++ b/parsing/parser.hs
@@ -32,7 +32,7 @@ parseString = do
 
 
 -- We're back to using the do-notation instead of the >> operator. This is because we'll be retrieving the value of our parse (returned by many(noneOf "\"")) and manipulating it, 
--- interleaving some other parse operations in the meantime. In general, use >> if the actions don't return a valuquite, >>= if you'll be immediately passing
+-- interleaving some other parse operations in the meantime. In general, use >> if the actions don't return a value, >>= if you'll be immediately passing
 -- that value into the next action, and do-notation
 -- otherwise.
 
@@ -138,7 +138,6 @@ eval env (List (func : args)) = do
 eval env badForm = throwError $ BadSpecialForm "(unrecognized special form): " badForm
 
 apply :: LispVal -> [LispVal] -> IOThrowsError LispVal
--- apply func args = maybe (throwError $ NotFunction "Unrecognized primitive function args " func) ($ args) $ lookup func primitives
 apply (PrimitiveFunc func) args = liftThrows $ func args
 apply (Func params vaargs body closure) args = 
       if num params /= num args && vaargs == Nothing -- ! Try without num just length

--- a/parsing/parser.hs
+++ b/parsing/parser.hs
@@ -14,6 +14,9 @@ data LispVal
   | Number Integer
   | String String
   | Bool Bool
+  | PrimitiveFunc ([LispVal] -> ThrowsError LispVal)
+  | Func { params :: [String], vaarg :: (Maybe String),
+           body :: [LispVal], closure :: Env }
 
 instance Show LispVal where show = showVal
 
@@ -29,7 +32,7 @@ parseString = do
 
 
 -- We're back to using the do-notation instead of the >> operator. This is because we'll be retrieving the value of our parse (returned by many(noneOf "\"")) and manipulating it, 
--- interleaving some other parse operations in the meantime. In general, use >> if the actions don't return a value, >>= if you'll be immediately passing
+-- interleaving some other parse operations in the meantime. In general, use >> if the actions don't return a valuquite, >>= if you'll be immediately passing
 -- that value into the next action, and do-notation
 -- otherwise.
 
@@ -118,11 +121,40 @@ eval env (List [Atom "set!", Atom var, form]) =
      eval env form >>= setVar env var
 eval env (List [Atom "define", Atom var, form]) =
      eval env form >>= defineVar env var
-eval env (List (Atom func : args)) = mapM (eval env) args >>= liftThrows . apply func
+eval env (List (Atom "define" : List (Atom var : params) : body)) =
+     makeNormalFunc env params body >>= defineVar env var
+eval env (List (Atom "define" : DottedList (Atom var : params) vaargs : body)) =
+     makeVarArgs vaargs env params body >>= defineVar env var
+eval env (List (Atom "lambda" : List params : body)) =
+     makeNormalFunc env params body
+eval env (List (Atom "lambda" : DottedList params vaargs : body)) =
+     makeVarArgs vaargs env params body
+eval env (List (Atom "lambda" : vaargs@(Atom _) : body)) =
+     makeVarArgs vaargs env [] body
+eval env (List (func : args)) = do
+     func <- eval env func
+     argVals <- mapM (eval env) args
+     apply func argVals
 eval env badForm = throwError $ BadSpecialForm "(unrecognized special form): " badForm
 
-apply :: String -> [LispVal] -> ThrowsError LispVal
-apply func args = maybe (throwError $ NotFunction "Unrecognized primitive function args " func) ($ args) $ lookup func primitives
+apply :: LispVal -> [LispVal] -> IOThrowsError LispVal
+-- apply func args = maybe (throwError $ NotFunction "Unrecognized primitive function args " func) ($ args) $ lookup func primitives
+apply (PrimitiveFunc func) args = liftThrows $ func args
+apply (Func params vaargs body closure) args = 
+      if num params /= num args && vaargs == Nothing -- ! Try without num just length
+        then throwError $ NumArgs (num params) args
+        else (liftIO $ bindVars closure $ zip params args) >>= bindVarArgs vaargs >>= evalBody
+      where
+        remainingArgs = drop (length params) args
+        num = toInteger . length
+        bindVarArgs args env = case args of
+          Just argName -> liftIO $ bindVars env [(argName, List remainingArgs)]
+          Nothing -> return env
+        evalBody env = liftM last $ mapM (eval env) body
+
+makeFunc vaargs env params body = return $ Func (map showVal params) vaargs body env
+makeNormalFunc = makeFunc Nothing
+makeVarArgs = makeFunc . Just . showVal
 
 -- # Primitive functions
 
@@ -155,6 +187,12 @@ primitives = [
   ("eqv?", eqv),
   ("eq?", eqv),
   ("equal?", equal)]
+
+primitiveBindings :: IO Env
+primitiveBindings = nullEnv >>= flip bindVars (map makePrimitiveFunc primitives)
+  where
+    makePrimitiveFunc :: (String, [LispVal] -> ThrowsError LispVal) -> (String, LispVal)
+    makePrimitiveFunc (var, func) = (var, PrimitiveFunc func)
 
 boolBinop :: (LispVal -> ThrowsError a) -> (a -> a -> Bool) -> [LispVal] -> ThrowsError LispVal
 boolBinop unpacker op args = if length args /= 2
@@ -254,7 +292,13 @@ showVal (Bool True) = "#t"
 showVal (Bool False) = "#f"
 showVal (List contents) = "(" ++ unwordsList contents ++ ")"
 showVal (DottedList init last) = "(" ++ unwordsList init ++ " . " ++ show last ++ ")"
-
+showVal (PrimitiveFunc _) = "<primitive>"
+showVal (Func {params = args, vaarg = vaargs, body = body, closure = env}) = 
+    "(lambda (" ++ unwords (map show args) ++
+        (case vaargs of
+          Nothing -> ""
+          Just arg -> " . " ++ arg) ++ ") ...)"
+ 
 -- make a string out of LispVal list with spaces
 unwordsList :: [LispVal] -> String
 unwordsList = unwords . map showVal
@@ -397,10 +441,10 @@ until_ pred prompt action = do
      else action result >> until_ pred prompt action
 
 runRepl :: IO ()
-runRepl = nullEnv >>= until_ (== "quit") (readPrompt "Haskeme>>") . evalAndPrint
+runRepl = primitiveBindings >>= until_ (== "quit") (readPrompt "Haskeme>>") . evalAndPrint
 
 runOne :: String -> IO ()
-runOne expr = nullEnv >>= flip evalAndPrint expr
+runOne expr = primitiveBindings >>= flip evalAndPrint expr
 
 -- TODO: (expr:_) <- getArgs .. what does (expr:_) means?
 main :: IO ()


### PR DESCRIPTION
Changes include:
- Primitive bindings are part of `LispVal` grammar
- Added support for `define` and `lambda`
- apply function no more throws `NotFunction` LispError, I wonder whether it should be part of grammar and if yes, does apply catch all the edge cases :question: 